### PR TITLE
prefixes by path instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A package and execution wrapper for AWS SSM Parameter expansion.
 ### CLI
 
 ```bash
-Usage: main [-g] [-p PREFIX] [COMMAND [ARGUMENTS [ARGUMENTS ...]]]
+Usage: main [-g] [-p PREFIX] [-v] [COMMAND [ARGUMENTS [ARGUMENTS ...]]]
 
 Positional arguments:
   COMMAND                Command to run
@@ -19,6 +19,7 @@ Positional arguments:
 Options:
   -g                     Do not inherit environment
   -p PREFIX              SSM prefixes to source
+  -v                     Verbose output
   --help, -h             display this help and exit
   --version              display version and exit
 ```
@@ -45,13 +46,13 @@ if err != nil {
 
 p := &kv.Parameters{Client: ssm.NewFromConfig(awsConfig)}
 
-// Get
-params, err := p.Get([]string{"/dev/foobar"})
+// Get parameters under provided prefixes
+params, err := p.Get([]string{"/dev"})
 if err != nil {
-  panic("error getting parameter")
+  panic("error getting parameters")
 }
 
-// Unmarshal
+// Unmarshal specific parameter into provided data type
 if err := p.Unmarshal("/dev/foobar", &data); err != nil {
   panic("error unmarshalling parameter")
 }

--- a/internal/mock/ssm.go
+++ b/internal/mock/ssm.go
@@ -7,12 +7,12 @@ import (
 )
 
 type MockSSMClient struct {
-	GetParametersFunc func(ctx context.Context, params *ssm.GetParametersInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersOutput, error)
-	GetParameterFunc  func(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+	GetParametersByPathFunc func(ctx context.Context, params *ssm.GetParametersByPathInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error)
+	GetParameterFunc        func(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
 }
 
-func (m *MockSSMClient) GetParameters(ctx context.Context, params *ssm.GetParametersInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersOutput, error) {
-	return m.GetParametersFunc(ctx, params, optFns...)
+func (m *MockSSMClient) GetParametersByPath(ctx context.Context, params *ssm.GetParametersByPathInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error) {
+	return m.GetParametersByPathFunc(ctx, params, optFns...)
 }
 
 func (m *MockSSMClient) GetParameter(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/alexflint/go-arg"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -17,6 +18,7 @@ var (
 type args struct {
 	Pristine      bool     `arg:"-g,--" help:"Do not inherit environment"`
 	ParamPrefixes []string `arg:"-p,--,separate" placeholder:"PREFIX" help:"SSM prefixes to source"`
+	Verbose       bool     `arg:"-v,--" help:"Verbose output"`
 	Command       string   `arg:"positional" help:"Command to run"`
 	Arguments     []string `arg:"positional" help:"Command arguments"`
 }
@@ -43,6 +45,18 @@ func main() {
 		panic(err)
 	}
 	e.Envs = params.Envs
+
+	if args.Verbose {
+		paramKeys := make([]string, 0, len(params.Map))
+		for k := range params.Map {
+			paramKeys = append(paramKeys, k)
+		}
+		if len(paramKeys) == 0 {
+			slog.Info("executing with no parameters", "command", e.Command)
+		} else {
+			slog.Info("executing with found parameters", "command", e.Command, "keys", paramKeys)
+		}
+	}
 
 	if err := e.Execute(); err != nil {
 		panic(err)

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -16,10 +16,10 @@ import (
 
 func TestExecute(t *testing.T) {
 	var (
-		prefixes      = []string{"/user-api/postgres", "/admin-api/redis"}
+		prefixes      = []string{"/user-api", "/admin-api"}
 		command       = "printenv"
 		arguments     = []string{}
-		ssmParameters = ssm.GetParametersOutput{
+		ssmParameters = ssm.GetParametersByPathOutput{
 			Parameters: []types.Parameter{
 				{
 					Name:  aws.String("/user-api/postgres"),
@@ -38,7 +38,7 @@ func TestExecute(t *testing.T) {
 		command       string
 		arguments     []string
 		pristine      bool
-		ssmParameters ssm.GetParametersOutput
+		ssmParameters ssm.GetParametersByPathOutput
 		awsError      error
 		expectedError error
 	}{
@@ -68,7 +68,7 @@ func TestExecute(t *testing.T) {
 			command:       command,
 			arguments:     arguments,
 			pristine:      false,
-			ssmParameters: ssm.GetParametersOutput{},
+			ssmParameters: ssm.GetParametersByPathOutput{},
 			awsError:      nil,
 			expectedError: fmt.Errorf("ahh!"),
 		},
@@ -77,7 +77,7 @@ func TestExecute(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			client := mock.MockSSMClient{}
-			client.GetParametersFunc = func(ctx context.Context, params *ssm.GetParametersInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersOutput, error) {
+			client.GetParametersByPathFunc = func(ctx context.Context, params *ssm.GetParametersByPathInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error) {
 				return &c.ssmParameters, c.awsError
 			}
 

--- a/pkg/kv/ssm.go
+++ b/pkg/kv/ssm.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
 
 type SSMClient interface {
-	GetParameters(ctx context.Context, params *ssm.GetParametersInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersOutput, error)
+	GetParametersByPath(ctx context.Context, params *ssm.GetParametersByPathInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error)
 	GetParameter(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
 }
 
@@ -25,15 +26,21 @@ func NewClient(client SSMClient) *Parameters {
 }
 
 func (p *Parameters) Get(prefixes []string) (*KV, error) {
-	withDecryption := true
-	input := &ssm.GetParametersInput{
-		Names:          prefixes,
-		WithDecryption: &withDecryption,
-	}
+	var results *ssm.GetParametersByPathOutput
+	for _, prefix := range prefixes {
+		if err := validatePrefixPath(prefix); err != nil {
+			return nil, err
+		}
 
-	results, err := p.Client.GetParameters(context.TODO(), input)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving parameters: %w", err)
+		var err error
+		results, err = p.Client.GetParametersByPath(context.TODO(), &ssm.GetParametersByPathInput{
+			Path:           &prefix,
+			Recursive:      aws.Bool(true),
+			WithDecryption: aws.Bool(true),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving parameters under path %s: %w", prefix, err)
+		}
 	}
 
 	kv := make(map[string]any)
@@ -41,7 +48,7 @@ func (p *Parameters) Get(prefixes []string) (*KV, error) {
 		if json.Valid([]byte(*result.Value)) {
 			var v map[string]any
 			if err := json.Unmarshal([]byte(*result.Value), &v); err != nil {
-				return nil, fmt.Errorf("error unmarshalling parameter: %w", err)
+				return nil, fmt.Errorf("error unmarshalling parameter %s: %w", *result.Name, err)
 			}
 
 			for k, v := range v {
@@ -68,11 +75,23 @@ func (p *Parameters) Unmarshal(prefix string, v any) error {
 
 	result, err := p.Client.GetParameter(context.TODO(), input)
 	if err != nil {
-		return fmt.Errorf("error retrieving parameter: %w", err)
+		return fmt.Errorf("error retrieving parameter %s: %w", prefix, err)
 	}
 
 	if err := json.Unmarshal([]byte(*result.Parameter.Value), &v); err != nil {
-		return fmt.Errorf("error unmarshalling parameter: %w", err)
+		return fmt.Errorf("error unmarshalling parameter %s: %w", prefix, err)
+	}
+
+	return nil
+}
+
+func validatePrefixPath(prefix string) error {
+	if strings.HasSuffix(prefix, "/") {
+		return fmt.Errorf("prefixes must not end with a slash: %s", prefix)
+	}
+
+	if strings.Contains(prefix, "//") {
+		return fmt.Errorf("prefixes must not contain double slashes: %s", prefix)
 	}
 
 	return nil

--- a/pkg/kv/ssm_test.go
+++ b/pkg/kv/ssm_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestGet(t *testing.T) {
 	var (
-		prefixes = []string{"/user-api/postgres", "/admin-api/redis"}
+		prefixes = []string{"/user-api"}
 		kv       = KV{
 			Map: map[string]any{
 				"postgres_user": "user-api",
@@ -29,7 +29,7 @@ func TestGet(t *testing.T) {
 				"redis_port=6379",
 			},
 		}
-		ssmParameters = ssm.GetParametersOutput{
+		ssmParameters = ssm.GetParametersByPathOutput{
 			Parameters: []types.Parameter{
 				{
 					Name:  aws.String("/user-api/postgres"),
@@ -46,7 +46,7 @@ func TestGet(t *testing.T) {
 		name          string
 		prefixes      []string
 		kv            KV
-		ssmParameters ssm.GetParametersOutput
+		ssmParameters ssm.GetParametersByPathOutput
 		awsError      error
 		expectedError error
 	}{
@@ -62,16 +62,16 @@ func TestGet(t *testing.T) {
 			name:          "error retrieving parameters",
 			prefixes:      prefixes,
 			kv:            KV{},
-			ssmParameters: ssm.GetParametersOutput{},
+			ssmParameters: ssm.GetParametersByPathOutput{},
 			awsError:      fmt.Errorf("ahh!"),
-			expectedError: fmt.Errorf("error retrieving parameters: %w", fmt.Errorf("ahh!")),
+			expectedError: fmt.Errorf("error retrieving parameters under path %s: %w", prefixes[0], fmt.Errorf("ahh!")),
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			client := mock.MockSSMClient{}
-			client.GetParametersFunc = func(ctx context.Context, params *ssm.GetParametersInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersOutput, error) {
+			client.GetParametersByPathFunc = func(ctx context.Context, params *ssm.GetParametersByPathInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error) {
 				return &c.ssmParameters, c.awsError
 			}
 
@@ -126,7 +126,7 @@ func TestUnmarshal(t *testing.T) {
 			targetStruct:  postgresSecrets{},
 			ssmParameter:  ssm.GetParameterOutput{},
 			awsError:      fmt.Errorf("ahh!"),
-			expectedError: fmt.Errorf("error retrieving parameter: %w", fmt.Errorf("ahh!")),
+			expectedError: fmt.Errorf("error retrieving parameter %s: %w", prefix, fmt.Errorf("ahh!")),
 		},
 		{
 			name:          "error unmarshalling parameter",


### PR DESCRIPTION
Changes:
- Uses SSM's `GetParameterByPath` method instead to allow recursive parameter lookup

Adds:
- Verbose (`-v`) flag to log command being executed and parameter keys found